### PR TITLE
Faster clone (8-12% perf win)

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -5,16 +5,16 @@ if (!Array.isArray) {
 }
 
 // deep clone an array of coordinates / polygons
-exports.clone = function(array) {
-  var new_arr = [];
-  for (var i = 0; i < array.length; i++) {
-    if (Array.isArray(array[i])){
-      new_arr.push(exports.clone(array[i]).slice());
-    } else {
-      new_arr.push(array[i]);
+exports.clone = function cloneArray(array) {
+  var newArray = array.slice();
+
+  for (var i = 0; i < newArray.length; i++) {
+    if (Array.isArray(newArray[i])) {
+      newArray[i] = cloneArray(newArray[i]);
     }
   }
-  return new_arr;
+
+  return newArray;
 }
 
 // Wrap an array of geometries to an array of polygons


### PR DESCRIPTION
Just a minor optimization. It looks like previously it was doing cloning twice on nested arrays.

```
# before
intersect#simple x 57,582 ops/sec ±0.98% (96 runs sampled)
intersect#armenia x 28,983 ops/sec ±0.83% (95 runs sampled)

# after
intersect#simple x 61,887 ops/sec ±0.83% (98 runs sampled)
intersect#armenia x 32,501 ops/sec ±0.78% (94 runs sampled)
```
